### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     'httpx',
     'loguru',
     # 'jmespath',
-    'fuzzywuzzy',
+    'rapidfuzz',
     'freemt_utils',
 ]
 

--- a/sogou_tr_async/sogou_tr_async.py
+++ b/sogou_tr_async/sogou_tr_async.py
@@ -9,7 +9,7 @@ import hashlib
 
 import httpx
 # from jmespath import search  # type: ignore
-from fuzzywuzzy import fuzz, process  # type: ignore
+from rapidfuzz import process  # type: ignore
 
 from loguru import logger
 
@@ -97,9 +97,9 @@ async def sogou_tr_async(  # pylint: disable=too-many-arguments
 
     if fuzzy:
         if from_lang not in SOGOUTR_CODES:
-            from_lang = process.extractOne(from_lang, SOGOUTR_CODES, scorer=fuzz.UWRatio)[0]  # NOQA
+            from_lang = process.extractOne(from_lang, SOGOUTR_CODES)[0]  # NOQA
         if to_lang not in SOGOUTR_CODES:
-            to_lang = process.extractOne(to_lang, SOGOUTR_CODES, scorer=fuzz.UWRatio)[0]  # NOQA
+            to_lang = process.extractOne(to_lang, SOGOUTR_CODES)[0]  # NOQA
 
     if from_lang == to_lang:
         sogou_tr_async.text = 'nothing to do'


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it faster than FuzzyWuzzy.